### PR TITLE
Don't convert the index columns produced by Pandas.

### DIFF
--- a/src/circuit/sonata_writer.cpp
+++ b/src/circuit/sonata_writer.cpp
@@ -26,7 +26,7 @@ using namespace arrow;
 using namespace std;
 
 
-static const unordered_set<string> COLUMNS_TO_SKIP{"synapse_id"};
+static const unordered_set<string> COLUMNS_TO_SKIP{"synapse_id", "__index_level_0__"};
 
 
 SonataWriter::SonataWriter(const string & filepath,


### PR DESCRIPTION
If scientists write Parquet files with Pandas, via
`DataFrame.to_parquet`, they will have to add `index=False` to skip
writing the index to disk, too. In the most simple and common case, this
index will show up as an additional column `__index_level_0__` and end
up in the edge files.

Make scientists and our lives a little simpler and skip converting this
index column.
